### PR TITLE
feat: Adding some better internal types and stronger linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,12 +12,15 @@ module.exports = {
     plugins: ["@typescript-eslint", "prettier"],
     rules: {
         camelcase: 0,
-        "no-unused-vars":1,
+        "no-unused-vars": 1,
         "no-undef": 0,
         "sort-keys": [
             "error",
             "asc",
             { caseSensitive: true, natural: false, minKeys: 2 },
         ],
+        "@typescript-eslint/member-ordering": 2,
+        "@typescript-eslint/no-explicit-any": 2,
+        "class-methods-use-this": 2,
     },
 };

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint 'lib/**/*.ts' --fix",
     "prepublish": "yarn run build",
     "release": "standard-version",
-    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'test/**/*.ts'"
+    "test": "DEBUG='winston-azure-blob' env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'test/**/*.ts'"
   },
   "dependencies": {
     "@azure/storage-blob": "^12.8.0",


### PR DESCRIPTION
**Description: Slight refactor PR that improves types and code organization**
- Replace some `any`'s with a more appropriate data type
- Remove `_` prefix from method names (this is not really descriptive or required)
- Reorganize methods using `"@typescript-eslint/member-ordering"` and `"class-methods-use-this"`
- Add `"@typescript-eslint/no-explicit-any"`