### PR TITLE
chore: Allowing for a string file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.4.2](https://github.com/agmoss/winston-azure-blob/compare/v1.4.1...v1.4.2) (2023-12-02)
+
 ### [1.4.1](https://github.com/agmoss/winston-azure-blob/compare/v1.4.0...v1.4.1) (2023-09-20)
 
 ## [1.4.0](https://github.com/agmoss/winston-azure-blob/compare/v1.3.1...v1.4.0) (2023-07-17)

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ logger.warn("Hello!");
 
 ## API
 
-| Parameter       | Data Type              | Description                                                                                                         | Default           | Type/Options            |
-| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- | ----------------------- |
-| `account`       | Object                 | Azure storage account credentials. Can provide either `name` & `key`, `host` & `sasToken`, or a `connectionString`. |                   | See below               |
-| `blobName`      | String                 | The name of the blob to log.                                                                                        |                   |                         |
-| `bufferLogSize` | Integer                | A minimum number of logs before syncing the blob.                                                                   | -1                |                         |
-| `containerName` | String                 | The container which will contain the logs.                                                                          |                   |                         |
-| `eol`           | String                 | The character appended to each log.                                                                                 | "\n"              |                         |
-| `extension`     | String                 | The file extension for the log file. Only ".log" is currently supported.                                            | No file extension | `.log` via `extensions` |
-| `level`         | String                 | Log level of messages for the transport.                                                                            | `info`            |                         |
-| `rotatePeriod`  | String (formatted)     | A moment format for blob name generation. Ex: `YYYY-MM-DD` will generate `blobName.2000.01.01`.                     | ""                |                         |
-| `syncTimeout`   | Integer (milliseconds) | The maximum time between two sync calls. Set to zero for realtime logging.                                          | 0                 |                         |
+| Parameter       | Data Type              | Description                                                                                                         | Default           | Type/Options                                     |
+| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------ |
+| `account`       | Object                 | Azure storage account credentials. Can provide either `name` & `key`, `host` & `sasToken`, or a `connectionString`. |                   | See below                                        |
+| `blobName`      | String                 | The name of the blob to log.                                                                                        |                   |                                                  |
+| `bufferLogSize` | Integer                | A minimum number of logs before syncing the blob.                                                                   | -1                |                                                  |
+| `containerName` | String                 | The container which will contain the logs.                                                                          |                   |                                                  |
+| `eol`           | String                 | The character appended to each log.                                                                                 | "\n"              |                                                  |
+| `extension`     | String                 | The file extension for the log file.                                                                                | No file extension | `.log` via `extensions` or string file extension |
+| `level`         | String                 | Log level of messages for the transport.                                                                            | `info`            |                                                  |
+| `rotatePeriod`  | String (formatted)     | A moment format for blob name generation. Ex: `YYYY-MM-DD` will generate `blobName.2000.01.01`.                     | ""                |                                                  |
+| `syncTimeout`   | Integer (milliseconds) | The maximum time between two sync calls. Set to zero for realtime logging.                                          | 0                 |                                                  |
 
 ### Account Credentials Options:
 
@@ -80,7 +80,6 @@ logger.warn("Hello!");
 | `host`             | String    | HTTP address of the storage account.                 |
 | `sasToken`         | String    | Shared access signature of the storage account.      |
 | `connectionString` | String    | A connection string for the storage account.         |
-
 
 ## Inspo & Credit
 

--- a/lib/winston-azure-blob.ts
+++ b/lib/winston-azure-blob.ts
@@ -33,7 +33,7 @@ export interface IWinstonAzureBlob {
     bufferLogSize: number;
     containerName: string;
     eol: string;
-    extension?: extensions;
+    extension?: extensions | string;
     rotatePeriod: string;
     syncTimeout: number;
     timeoutFn?: NodeJS.Timeout | null;
@@ -71,7 +71,7 @@ export class WinstonAzureBlob extends Transport implements IWinstonAzureBlob {
     bufferLogSize: number;
     containerName: string;
     eol: string;
-    extension: extensions | undefined;
+    extension?: extensions | string;
     rotatePeriod: string;
     syncTimeout: number;
     timeoutFn: NodeJS.Timeout | null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-azure-blob",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "NEW winston transport for azure blob storage",
   "keywords": [
     "winston",

--- a/test/test.ts
+++ b/test/test.ts
@@ -106,6 +106,31 @@ describe("WinstonAzureBlob", () => {
         );
     });
 
+    it("has a proper file name with opts and string extension", () => {
+        const azBlob = winstonAzureBlob({
+            account: {
+                host: process.env.HOST || "host",
+                sasToken: process.env.SAS_TOKEN || "sasToken",
+            },
+            bufferLogSize: 1,
+            extension: ".json",
+            level: "info",
+            rotatePeriod: "YYYY-MM-DD",
+            syncTimeout: 0,
+            ...constants,
+        });
+
+        const generatedBlobName = WinstonAzureBlob.generateBlobName({
+            blobName: azBlob.blobName,
+            extension: azBlob.extension,
+            rotatePeriod: azBlob.rotatePeriod,
+        });
+
+        expect(generatedBlobName).to.equal(
+            constants.blobName + "." + formatYmd(new Date()) + ".json"
+        );
+    });
+
     it("sends logs", async () => {
         const contents = randAnimalType();
 


### PR DESCRIPTION
- A string can now be used to set the `extension` option.
- Closes #14 